### PR TITLE
Djm/fix ec vignette

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -7,3 +7,5 @@
 ^docs$
 ^pkgdown$
 ^\.vscode$
+^doc$
+^Meta$

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ src/*.dll
 .vscode
 docs
 inst/doc
+/doc/
+/Meta/

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,12 +17,9 @@ Depends:
 Imports: 
     cli,
     ggplot2,
-    httr,
     magrittr,
     methods,
-    pandoc,
     Rcpp,
-    readr,
     rlang,
     vctrs,
     zoo


### PR DESCRIPTION
This should fix some of the bugs.

Once you merge this onto your branch:
* Use the instructions [here](https://r-pkgs.org/data.html#sec-data-data-raw) to put the Canadian data into the package. Basically, you'll create an R script that downloads the data and ends with `usethis::use_data()`. Then document that data object as described there.
* Then remove the `library(httr)` call from the Vignette. Tests should pass by that point.

One other major comment on the Vignette: Set a seed before generating the data. The results don't always look great.