### PR TITLE
adjust dof detection tolerance

### DIFF
--- a/R/find_knots.R
+++ b/R/find_knots.R
@@ -27,9 +27,9 @@ find_knots.poisson_rt <- function(object, lambda, ...) {
   dof <- object$dof
   dof <- dof[lam_list$left] * lam_list$frac +
     dof[lam_list$right] * (1 - lam_list$frac)
-  knots <- which(abs(alp) > object$tolerance)
+  knots <- which(abs(alp) > 1e-10)
   r <- c(knots + object$korder, n)
   l <- c(1, knots + object$korder + 1)
-  pieces <- map2(l, r, function(a, b) object$x[a:b])
-  list(knots = knots, pieces = pieces, dof = dof)
+  xpieces <- map2(l, r, function(a, b) object$x[a:b])
+  enlist(knots, xpieces, dof, l, r)
 }

--- a/src/rtestim_path.cpp
+++ b/src/rtestim_path.cpp
@@ -99,7 +99,7 @@ List rtestim_path(NumericVector y,
       theta(_, i) = exp(beta);
       alp(_, i) = diff(alpha);
     }
-    nknots[i] = sum(abs(alp(_, i)) > tolerance);
+    nknots[i] = sum(abs(alp(_, i)) > 1e-10);
 
     // Verbose handlers
     if (verbose > 1) Rcout << niter(i);


### PR DESCRIPTION
I made a few more changes to the confidence bands. There seemed to be two issues:
1. The tolerance for finding changes in alpha was too small in the cpp code (was set to the tolerance parameter, default to 1e-4).
2. For the Canadian data, the sequence is so long, the lambdas so big, that it wasn’t really “converging” all the time. For the paper, you should run it for more iterations and with smaller tolerance.

I also simplified the computation of the bands. I like the old way better, but it can lead to some issues for some segments if the knots are close together. And the bands get too wide near the knots. There’s still an issue that for large counts (as in the Canadian data), the bands get too narrow. It’s because of `1/yhat^2`. If that drops below some threshold, then `(1/yhat^2 + lambda * D’D)` can have very small eigenvalues. But I can’t figure out the correct threshold. So we should just leave it for now.